### PR TITLE
feat: add JWT token decoder to Scratchpad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is the first release of LogSquirl, a GPL-3.0 fork of [klogg](https://github
 
 ## New features:
  - Rebranded project from klogg to LogSquirl with new bundle identifier `io.github.logsquirl`
+ - Added JWT token decoder to Scratchpad: decodes Base64URL header/payload, formats JSON with indentation, and annotates epoch timestamps (iat, exp, nbf, auth_time) with human-readable UTC dates
 
 ## Bug fixes:
  - Fixed crash on shutdown with Qt 6.10 on Windows (QThreadPool::waitForDone SEGFAULT)

--- a/src/ui/include/jwtdecoder.h
+++ b/src/ui/include/jwtdecoder.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 LogSquirl Contributors
+ *
+ * This file is part of LogSquirl.
+ *
+ * LogSquirl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LogSquirl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LogSquirl.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+#include <QTimeZone>
+
+namespace logsquirl {
+namespace jwt {
+
+// Decode a Base64URL-encoded segment (RFC 7515) to a byte array.
+// JWT uses '-' instead of '+', '_' instead of '/', and omits trailing '=' padding.
+inline QByteArray decodeBase64Url( const QByteArray& input )
+{
+    QByteArray base64 = input;
+    base64.replace( '-', '+' );
+    base64.replace( '_', '/' );
+
+    const int pad = ( 4 - base64.size() % 4 ) % 4;
+    base64.append( pad, '=' );
+
+    return QByteArray::fromBase64( base64 );
+}
+
+// Format a JSON object with human-readable timestamps for known JWT epoch fields.
+// Annotates iat, exp, nbf, and auth_time values with their UTC date/time.
+inline QString formatJwtJson( const QByteArray& jsonBytes )
+{
+    QJsonParseError parseError;
+    const auto doc = QJsonDocument::fromJson( jsonBytes, &parseError );
+    if ( doc.isNull() || !doc.isObject() ) {
+        return QString::fromUtf8( jsonBytes );
+    }
+
+    const auto indented = doc.toJson( QJsonDocument::Indented );
+    auto result = QString::fromUtf8( indented );
+
+    static const QStringList epochFields = { "iat", "exp", "nbf", "auth_time" };
+    const auto obj = doc.object();
+
+    for ( const auto& field : epochFields ) {
+        if ( !obj.contains( field ) ) {
+            continue;
+        }
+        const auto val = obj.value( field );
+        if ( !val.isDouble() ) {
+            continue;
+        }
+
+        const auto epoch = static_cast<qint64>( val.toDouble() );
+        const auto dt = QDateTime::fromSecsSinceEpoch( epoch, QTimeZone::utc() );
+        const auto readable = dt.toString( "yyyy-MM-ddThh:mm:ssZ" );
+
+        // Annotate the numeric value in the formatted output with the readable date
+        const auto pattern
+            = QString( "\"%1\": %2" ).arg( field ).arg( epoch );
+        const auto annotated
+            = QString( "\"%1\": %2  // %3" ).arg( field ).arg( epoch ).arg( readable );
+        result.replace( pattern, annotated );
+    }
+
+    return result;
+}
+
+// Decode a complete JWT token string into a formatted human-readable representation.
+// Returns an empty string if the input is not a valid JWT structure.
+inline QString decodeToken( const QString& token )
+{
+    const auto trimmed = token.trimmed();
+    const auto parts = trimmed.split( '.' );
+    if ( parts.size() < 2 || parts.size() > 3 ) {
+        return QString{};
+    }
+
+    const auto headerBytes = decodeBase64Url( parts[ 0 ].toUtf8() );
+    const auto payloadBytes = decodeBase64Url( parts[ 1 ].toUtf8() );
+
+    QString result;
+    result += QString::fromUtf8( "═══ JWT Header ═══\n" );
+    result += formatJwtJson( headerBytes );
+    result += '\n';
+    result += QString::fromUtf8( "\n═══ JWT Payload ═══\n" );
+    result += formatJwtJson( payloadBytes );
+    result += '\n';
+
+    if ( parts.size() == 3 && !parts[ 2 ].isEmpty() ) {
+        const auto sigBytes = decodeBase64Url( parts[ 2 ].toUtf8() );
+        result += QString::fromUtf8( "\n═══ Signature ═══\n" );
+        result += QString::fromLatin1( sigBytes.toHex() );
+        result += '\n';
+    }
+
+    return result;
+}
+
+} // namespace jwt
+} // namespace logsquirl

--- a/src/ui/include/jwtdecoder.h
+++ b/src/ui/include/jwtdecoder.h
@@ -38,7 +38,7 @@ inline QByteArray decodeBase64Url( const QByteArray& input )
     base64.replace( '-', '+' );
     base64.replace( '_', '/' );
 
-    const int pad = ( 4 - base64.size() % 4 ) % 4;
+    const int pad = static_cast<int>( ( 4 - base64.size() % 4 ) % 4 );
     base64.append( pad, '=' );
 
     return QByteArray::fromBase64( base64 );

--- a/src/ui/include/scratchpad.h
+++ b/src/ui/include/scratchpad.h
@@ -67,6 +67,7 @@ class ScratchPad : public QWidget {
     void formatXml();
 
     void decodeUrl();
+    void decodeJwt();
 
     QString transformText( const std::function<QString( QString )>& transform );
 

--- a/src/ui/src/scratchpad.cpp
+++ b/src/ui/src/scratchpad.cpp
@@ -31,6 +31,7 @@
 #include <QDomDocument>
 #include <QFormLayout>
 #include <QJsonDocument>
+#include <QJsonObject>
 #include <QLineEdit>
 #include <QPlainTextEdit>
 #include <QStatusBar>
@@ -41,6 +42,7 @@
 
 #include "crc32.h"
 #include "clipboard.h"
+#include "jwtdecoder.h"
 
 namespace logsquirl {
 
@@ -117,6 +119,12 @@ ScratchPad::ScratchPad( QWidget* parent )
     auto decodeUrlAction = std::make_unique<QAction>( "Decode url" );
     connect( decodeUrlAction.get(), &QAction::triggered, [ this ]( auto ) { decodeUrl(); } );
     toolBar->addAction( decodeUrlAction.release() );
+
+    toolBar->addSeparator();
+
+    auto decodeJwtAction = std::make_unique<QAction>( "Decode JWT" );
+    connect( decodeJwtAction.get(), &QAction::triggered, [ this ]( auto ) { decodeJwt(); } );
+    toolBar->addAction( decodeJwtAction.release() );
 
     toolBar->addSeparator();
 
@@ -357,6 +365,12 @@ void ScratchPad::formatXml()
 
         return xml.toString( 2 );
     } );
+}
+
+void ScratchPad::decodeJwt()
+{
+    transformTextInPlace(
+        []( QString text ) { return logsquirl::jwt::decodeToken( text ); } );
 }
 
 logsquirl::DateTimeBox::DateTimeBox()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(logsquirl_tests
     configuration_test.cpp
     encodingdetector_test.cpp
+    jwtdecoder_test.cpp
     linepositionarray_test.cpp
     linetypes_test.cpp
     patternmatcher_test.cpp

--- a/tests/unit/jwtdecoder_test.cpp
+++ b/tests/unit/jwtdecoder_test.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (C) 2026 LogSquirl Contributors
+ *
+ * This file is part of LogSquirl.
+ *
+ * LogSquirl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LogSquirl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LogSquirl.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "jwtdecoder.h"
+
+#include <QByteArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+using namespace logsquirl::jwt;
+
+SCENARIO( "Base64URL decoding handles JWT-specific encoding", "[jwtdecoder]" )
+{
+    GIVEN( "A standard Base64URL string with no padding" )
+    {
+        // "Hello" in Base64URL is "SGVsbG8" (no padding)
+        const QByteArray input = "SGVsbG8";
+
+        WHEN( "It is decoded" )
+        {
+            const auto result = decodeBase64Url( input );
+
+            THEN( "The original bytes are recovered" )
+            {
+                REQUIRE( result == "Hello" );
+            }
+        }
+    }
+
+    GIVEN( "A Base64URL string using URL-safe characters" )
+    {
+        // Standard base64 "n/+w" becomes "n_-w" in Base64URL
+        const QByteArray standard = "n/+w";
+        const QByteArray urlSafe = "n_-w";
+
+        WHEN( "The URL-safe variant is decoded" )
+        {
+            const auto fromUrlSafe = decodeBase64Url( urlSafe );
+            const auto fromStandard = QByteArray::fromBase64( standard );
+
+            THEN( "Both produce the same result" )
+            {
+                REQUIRE( fromUrlSafe == fromStandard );
+            }
+        }
+    }
+
+    GIVEN( "An empty input" )
+    {
+        const QByteArray input = "";
+
+        WHEN( "It is decoded" )
+        {
+            const auto result = decodeBase64Url( input );
+
+            THEN( "The result is empty" )
+            {
+                REQUIRE( result.isEmpty() );
+            }
+        }
+    }
+}
+
+SCENARIO( "JWT JSON formatting annotates epoch timestamps", "[jwtdecoder]" )
+{
+    GIVEN( "A JSON payload with iat and exp fields" )
+    {
+        QJsonObject obj;
+        obj[ "sub" ] = "1234567890";
+        obj[ "name" ] = "John Doe";
+        obj[ "iat" ] = 1516239022;
+        obj[ "exp" ] = 1516242622;
+
+        const auto jsonBytes = QJsonDocument( obj ).toJson( QJsonDocument::Compact );
+
+        WHEN( "It is formatted" )
+        {
+            const auto result = formatJwtJson( jsonBytes );
+
+            THEN( "The output contains the iat timestamp annotation" )
+            {
+                REQUIRE( result.contains( "\"iat\": 1516239022  // 2018-01-18T01:30:22Z" ) );
+            }
+
+            THEN( "The output contains the exp timestamp annotation" )
+            {
+                REQUIRE( result.contains( "\"exp\": 1516242622  // 2018-01-18T02:30:22Z" ) );
+            }
+
+            THEN( "Non-timestamp fields are not annotated" )
+            {
+                REQUIRE_FALSE( result.contains( "\"sub\": \"1234567890\"  //" ) );
+            }
+        }
+    }
+
+    GIVEN( "A JSON payload with nbf and auth_time fields" )
+    {
+        QJsonObject obj;
+        obj[ "nbf" ] = 0;
+        obj[ "auth_time" ] = 1609459200;
+
+        const auto jsonBytes = QJsonDocument( obj ).toJson( QJsonDocument::Compact );
+
+        WHEN( "It is formatted" )
+        {
+            const auto result = formatJwtJson( jsonBytes );
+
+            THEN( "nbf epoch 0 is annotated as 1970-01-01" )
+            {
+                REQUIRE( result.contains( "\"nbf\": 0  // 1970-01-01T00:00:00Z" ) );
+            }
+
+            THEN( "auth_time is annotated correctly" )
+            {
+                REQUIRE( result.contains( "\"auth_time\": 1609459200  // 2021-01-01T00:00:00Z" ) );
+            }
+        }
+    }
+
+    GIVEN( "Invalid JSON bytes" )
+    {
+        const QByteArray garbage = "not json at all";
+
+        WHEN( "It is formatted" )
+        {
+            const auto result = formatJwtJson( garbage );
+
+            THEN( "The raw input is returned unchanged" )
+            {
+                REQUIRE( result == "not json at all" );
+            }
+        }
+    }
+}
+
+SCENARIO( "Full JWT token decoding", "[jwtdecoder]" )
+{
+    GIVEN( "A valid 3-part JWT token" )
+    {
+        // Header: {"alg":"HS256","typ":"JWT"}
+        // Payload: {"sub":"1234567890","name":"John Doe","iat":1516239022}
+        // Signature: (dummy bytes)
+        const QString token
+            = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+              "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ."
+              "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+        WHEN( "It is decoded" )
+        {
+            const auto result = decodeToken( token );
+
+            THEN( "The result is not empty" )
+            {
+                REQUIRE_FALSE( result.isEmpty() );
+            }
+
+            THEN( "It contains the header section" )
+            {
+                REQUIRE( result.contains( QString::fromUtf8( "═══ JWT Header ═══" ) ) );
+            }
+
+            THEN( "It contains the payload section" )
+            {
+                REQUIRE( result.contains( QString::fromUtf8( "═══ JWT Payload ═══" ) ) );
+            }
+
+            THEN( "It contains the signature section" )
+            {
+                REQUIRE( result.contains( QString::fromUtf8( "═══ Signature ═══" ) ) );
+            }
+
+            THEN( "The header shows the algorithm" )
+            {
+                REQUIRE( result.contains( "\"alg\": \"HS256\"" ) );
+            }
+
+            THEN( "The payload shows the subject" )
+            {
+                REQUIRE( result.contains( "\"sub\": \"1234567890\"" ) );
+            }
+
+            THEN( "The iat timestamp is annotated with a readable date" )
+            {
+                REQUIRE( result.contains( "\"iat\": 1516239022  // 2018-01-18T01:30:22Z" ) );
+            }
+        }
+    }
+
+    GIVEN( "A JWT with only header and payload (no signature)" )
+    {
+        // Header: {"alg":"none"}
+        // Payload: {"sub":"test"}
+        const QString token = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.";
+
+        WHEN( "It is decoded" )
+        {
+            const auto result = decodeToken( token );
+
+            THEN( "The result contains header and payload" )
+            {
+                REQUIRE( result.contains( QString::fromUtf8( "═══ JWT Header ═══" ) ) );
+                REQUIRE( result.contains( QString::fromUtf8( "═══ JWT Payload ═══" ) ) );
+            }
+
+            THEN( "The signature section is not present for empty signature" )
+            {
+                REQUIRE_FALSE( result.contains( QString::fromUtf8( "═══ Signature ═══" ) ) );
+            }
+        }
+    }
+
+    GIVEN( "A token with leading and trailing whitespace" )
+    {
+        const QString token
+            = "  eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+              "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+              "dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U  \n";
+
+        WHEN( "It is decoded" )
+        {
+            const auto result = decodeToken( token );
+
+            THEN( "Whitespace is trimmed and decoding succeeds" )
+            {
+                REQUIRE_FALSE( result.isEmpty() );
+                REQUIRE( result.contains( "\"alg\": \"HS256\"" ) );
+            }
+        }
+    }
+
+    GIVEN( "An invalid string with wrong number of parts" )
+    {
+        WHEN( "A string with only one part is decoded" )
+        {
+            const auto result = decodeToken( "justonepart" );
+
+            THEN( "The result is empty" )
+            {
+                REQUIRE( result.isEmpty() );
+            }
+        }
+
+        WHEN( "A string with four parts is decoded" )
+        {
+            const auto result = decodeToken( "a.b.c.d" );
+
+            THEN( "The result is empty" )
+            {
+                REQUIRE( result.isEmpty() );
+            }
+        }
+    }
+
+    GIVEN( "An empty string" )
+    {
+        WHEN( "It is decoded" )
+        {
+            const auto result = decodeToken( "" );
+
+            THEN( "The result is empty" )
+            {
+                REQUIRE( result.isEmpty() );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a 'Decode JWT' button to the Scratchpad toolbar that:
- Splits the token into header, payload, and signature parts
- Decodes Base64URL-encoded segments (RFC 7515)
- Formats the JSON with indentation
- Annotates epoch timestamp fields (iat, exp, nbf, auth_time) with human-readable UTC dates inline

The decoding logic is extracted into a reusable header (jwtdecoder.h) with comprehensive unit tests covering:
- Base64URL decoding (padding, URL-safe chars, empty input)
- Timestamp annotation for all supported epoch fields
- Full token decode with 3-part and 2-part tokens
- Whitespace trimming and invalid input rejection