### PR TITLE
feat: add fast scroll with Alt key (VSCode-style)

### DIFF
--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -480,6 +480,24 @@ class Configuration final : public Persistable<Configuration> {
         allowFollowOnScroll_ = enable;
     }
 
+    // Fast scroll: multiply scroll speed when Alt (Option) is held
+    bool fastScrollEnabled() const
+    {
+        return fastScrollEnabled_;
+    }
+    void setFastScrollEnabled( bool enable )
+    {
+        fastScrollEnabled_ = enable;
+    }
+    int fastScrollMultiplier() const
+    {
+        return fastScrollMultiplier_;
+    }
+    void setFastScrollMultiplier( int multiplier )
+    {
+        fastScrollMultiplier_ = multiplier;
+    }
+
     bool useTextWrap() const
     {
         return useTextWrap_;
@@ -605,6 +623,9 @@ class Configuration final : public Persistable<Configuration> {
 
     bool allowFollowOnScroll_ = true;
     bool autoRunSearchOnPatternChange_ = false;
+
+    bool fastScrollEnabled_ = true;
+    int fastScrollMultiplier_ = 5;
 
     bool optimizeForNotLatinEncodings_ = false;
 

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -199,6 +199,14 @@ void Configuration::retrieveFromStorage( QSettings& settings )
               .value( "filewatch.allowFollowOnScroll", DefaultConfiguration.allowFollowOnScroll_ )
               .toBool();
 
+    fastScrollEnabled_
+        = settings.value( "view.fastScrollEnabled", DefaultConfiguration.fastScrollEnabled_ )
+              .toBool();
+    fastScrollMultiplier_
+        = settings
+              .value( "view.fastScrollMultiplier", DefaultConfiguration.fastScrollMultiplier_ )
+              .toInt();
+
     loadLastSession_
         = settings.value( "session.loadLast", DefaultConfiguration.loadLastSession_ ).toBool();
     allowMultipleWindows_
@@ -380,6 +388,9 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "filewatch.pollingIntervalMs", pollIntervalMs_ );
     settings.setValue( "filewatch.fastModificationDetection", fastModificationDetection_ );
     settings.setValue( "filewatch.allowFollowOnScroll", allowFollowOnScroll_ );
+
+    settings.setValue( "view.fastScrollEnabled", fastScrollEnabled_ );
+    settings.setValue( "view.fastScrollMultiplier", fastScrollMultiplier_ );
 
     settings.setValue( "session.loadLast", loadLastSession_ );
     settings.setValue( "session.multipleWindows", allowMultipleWindows_ );

--- a/src/ui/include/optionsdialog.ui
+++ b/src/ui/include/optionsdialog.ui
@@ -439,6 +439,37 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="fastScrollEnabledCheckBox">
+            <property name="text">
+             <string>Enable fast scrolling with Alt key</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="fastScrollMultiplierLayout">
+            <item>
+             <widget class="QLabel" name="fastScrollMultiplierLabel">
+              <property name="text">
+               <string>Fast scroll multiplier</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="fastScrollMultiplierSpinBox">
+              <property name="minimum">
+               <number>2</number>
+              </property>
+              <property name="maximum">
+               <number>20</number>
+              </property>
+              <property name="value">
+               <number>5</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -941,6 +941,13 @@ void AbstractLogView::wheelEvent( QWheelEvent* wheelEvent )
         return;
     }
 
+    // Fast scroll: multiply scroll delta when Alt (Option on macOS) is held
+    const bool isFastScroll = wheelEvent->modifiers().testFlag( Qt::AltModifier )
+                              && Configuration::get().fastScrollEnabled();
+    if ( isFastScroll ) {
+        yDelta *= Configuration::get().fastScrollMultiplier();
+    }
+
     // LOG_DEBUG << "wheelEvent";
 
     // This is to handle the case where follow mode is on, but the user
@@ -969,7 +976,13 @@ void AbstractLogView::wheelEvent( QWheelEvent* wheelEvent )
     // LOG_DEBUG << "Length = " << followElasticHook_.size();
     if ( !allowFollowOnScroll
          || ( followElasticHook_.size() == 0 && !followElasticHook_.isHooked() ) ) {
-        QAbstractScrollArea::wheelEvent( wheelEvent );
+        if ( isFastScroll ) {
+            // Apply multiplied delta directly since the original event has the unmultiplied value
+            verticalScrollBar()->setValue( verticalScrollBar()->value() - yDelta );
+        }
+        else {
+            QAbstractScrollArea::wheelEvent( wheelEvent );
+        }
     }
 }
 

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -346,6 +346,9 @@ void OptionsDialog::updateDialogFromConfig()
     pollIntervalLineEdit->setText( QString::number( config.pollIntervalMs() ) );
     allowFollowOnScrollCheckBox->setChecked( config.allowFollowOnScroll() );
 
+    fastScrollEnabledCheckBox->setChecked( config.fastScrollEnabled() );
+    fastScrollMultiplierSpinBox->setValue( config.fastScrollMultiplier() );
+
     // Last session
     loadLastSessionCheckBox->setChecked( config.loadLastSession() );
     followFileOnLoadCheckBox->setChecked( config.followFileOnLoad() );
@@ -520,6 +523,9 @@ void OptionsDialog::updateConfigFromDialog()
     config.setPollIntervalMs( pollInterval );
     config.setFastModificationDetection( fastModificationDetectionCheckBox->isChecked() );
     config.setAllowFollowOnScroll( allowFollowOnScrollCheckBox->isChecked() );
+
+    config.setFastScrollEnabled( fastScrollEnabledCheckBox->isChecked() );
+    config.setFastScrollMultiplier( fastScrollMultiplierSpinBox->value() );
 
     config.setLoadLastSession( loadLastSessionCheckBox->isChecked() );
     config.setFollowFileOnLoad( followFileOnLoadCheckBox->isChecked() );


### PR DESCRIPTION
Hold Alt (Option on macOS) while scrolling to multiply the scroll speed. The multiplier defaults to 5x matching VSCode's editor.fastScrollSensitivity setting.

Settings added to Preferences dialog:
- Enable fast scrolling with Alt key (default: on)
- Fast scroll multiplier (range 2-20, default: 5)

The feature is enabled by default for immediate discoverability. Ctrl+scroll font zoom behavior is unchanged.