### PR TITLE
feat: add opt-in beta update channel with per-startup check

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -6,6 +6,9 @@ on:
       ci-run-id:
         description: "Run ID of CI workflow"
         required: false
+      beta-tag:
+        description: "Beta release tag (e.g. v26.04.0-beta.1). Leave empty for standard CI release."
+        required: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -140,6 +143,69 @@ jobs:
         files: |
           ./packages-macos-intel-qt6/*
           ./packages-macos-arm-qt6/*
+
+    # --- Beta release (only when beta-tag input is provided) ---
+    - name: Release beta win
+      if: ${{ github.event.inputs.beta-tag }}
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.LOGSQUIRL_GITHUB_TOKEN }}
+        automatic_release_tag: ${{ github.event.inputs.beta-tag }}-win
+        prerelease: true
+        title: "Beta ${{ github.event.inputs.beta-tag }} (Windows)"
+        files: |
+          ./packages-windows-x64-qt6/*
+
+    - name: Release beta linux
+      if: ${{ github.event.inputs.beta-tag }}
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.LOGSQUIRL_GITHUB_TOKEN }}
+        automatic_release_tag: ${{ github.event.inputs.beta-tag }}-linux
+        prerelease: true
+        title: "Beta ${{ github.event.inputs.beta-tag }} (Linux)"
+        files: |
+          ./packages-jammy/*
+          ./packages-noble/*
+          ./packages-oracle/*
+          ./packages-fedora/*
+          ./packages-appimage/*
+          ./packages-bin/*
+          ./linux-debug/*
+
+    - name: Release beta mac
+      if: ${{ github.event.inputs.beta-tag }}
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.LOGSQUIRL_GITHUB_TOKEN }}
+        automatic_release_tag: ${{ github.event.inputs.beta-tag }}-osx
+        prerelease: true
+        title: "Beta ${{ github.event.inputs.beta-tag }} (macOS)"
+        files: |
+          ./packages-macos-intel-qt6/*
+          ./packages-macos-arm-qt6/*
+
+    - name: Update latest.json with beta version
+      if: ${{ github.event.inputs.beta-tag }}
+      shell: bash
+      env:
+        BETA_TAG: ${{ github.event.inputs.beta-tag }}
+      run: |
+        # Extract version from tag (strip leading 'v' if present)
+        BETA_VERSION="${BETA_TAG#v}"
+        BETA_URL="https://github.com/64x-lunicorn/LogSquirl/releases/tag/${BETA_TAG}"
+
+        # Update latest.json using jq
+        jq --arg ver "$BETA_VERSION" --arg url "$BETA_URL" \
+           '.beta = $ver | .beta_url = $url' latest.json > latest.json.tmp \
+           && mv latest.json.tmp latest.json
+
+        # Commit and push the updated latest.json
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add latest.json
+        git commit -m "chore: update latest.json with beta ${BETA_VERSION} [skip ci]"
+        git push
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the first release of LogSquirl, a GPL-3.0 fork of [klogg](https://github
  - Added JWT token decoder to Scratchpad: decodes Base64URL header/payload, formats JSON with indentation, and annotates epoch timestamps (iat, exp, nbf, auth_time) with human-readable UTC dates
  - Added Filters Panel: right sidebar dock with tabbed Filters and Scratchpad panels, toolbar filter icon, auto-search on toggle, and pinned filters that persist across sessions
  - Added Chipmunk filter import: import filters and highlighters from Chipmunk JSON export files via Tools menu
+ - Added opt-in beta update channel: new "Check for beta updates" checkbox in Settings > General. When enabled, the app checks for beta versions on every startup (bypassing the 7-day interval) and shows notifications with "(Beta)" label
 
 ## Bug fixes:
  - Fixed crash on shutdown with Qt 6.10 on Windows (QThreadPool::waitForDone SEGFAULT)

--- a/latest.json
+++ b/latest.json
@@ -3,6 +3,8 @@
     "ci_url": "https://github.com/64x-lunicorn/LogSquirl/releases/tag/continuous",
     "stable": "26.03.0",
     "stable_url": "https://github.com/64x-lunicorn/LogSquirl/releases/tag/v26.03.0",
+    "beta": "",
+    "beta_url": "",
     "releases": [
         "17.12.0.245",
         "19.2.0.366",

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -260,6 +260,16 @@ class Configuration final : public Persistable<Configuration> {
         enableVersionChecking_ = enabled;
     }
 
+    // Whether the user opted in to beta update notifications
+    bool betaVersionCheckingEnabled() const
+    {
+        return enableBetaVersionChecking_;
+    }
+    void setBetaVersionCheckingEnabled( bool enabled )
+    {
+        enableBetaVersionChecking_ = enabled;
+    }
+
     // View settings
     bool isOverviewVisible() const
     {
@@ -602,6 +612,7 @@ class Configuration final : public Persistable<Configuration> {
     int loggingLevel_ = 4;
 
     bool enableVersionChecking_ = true;
+    bool enableBetaVersionChecking_ = false;
 
     bool extractArchives_ = true;
     bool extractArchivesAlways_ = false;

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -223,6 +223,10 @@ void Configuration::retrieveFromStorage( QSettings& settings )
     enableVersionChecking_
         = settings.value( "versionchecker.enabled", DefaultConfiguration.enableVersionChecking_ )
               .toBool();
+    enableBetaVersionChecking_
+        = settings.value( "versionchecker.betaEnabled",
+                          DefaultConfiguration.enableBetaVersionChecking_ )
+              .toBool();
 
     extractArchives_
         = settings.value( "archives.extract", DefaultConfiguration.extractArchives_ ).toBool();
@@ -400,6 +404,7 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "logging.verbosity", loggingLevel_ );
 
     settings.setValue( "versionchecker.enabled", enableVersionChecking_ );
+    settings.setValue( "versionchecker.betaEnabled", enableBetaVersionChecking_ );
 
     settings.setValue( "archives.extract", extractArchives_ );
     settings.setValue( "archives.extractAlways", extractArchivesAlways_ );

--- a/src/ui/include/optionsdialog.ui
+++ b/src/ui/include/optionsdialog.ui
@@ -216,6 +216,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="checkForBetaVersionCheckBox">
+            <property name="toolTip">
+             <string>When enabled, checks for beta versions on every application start</string>
+            </property>
+            <property name="text">
+             <string>Check for beta updates</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -84,6 +84,10 @@ OptionsDialog::OptionsDialog( QWidget* parent )
     connect( extractArchivesCheckBox, &QCheckBox::toggled,
              [ this ]( auto ) { this->setupArchives(); } );
 
+    // Beta checkbox is only enabled when version checking is on
+    connect( checkForNewVersionCheckBox, &QCheckBox::toggled, checkForBetaVersionCheckBox,
+             &QWidget::setEnabled );
+
     connect( mainSearchColorButton, &QPushButton::clicked, this, &OptionsDialog::changeMainColor );
     connect( quickFindColorButton, &QPushButton::clicked, this, &OptionsDialog::changeQfColor );
 
@@ -373,6 +377,8 @@ void OptionsDialog::updateDialogFromConfig()
 
     // version checking
     checkForNewVersionCheckBox->setChecked( config.versionCheckingEnabled() );
+    checkForBetaVersionCheckBox->setChecked( config.betaVersionCheckingEnabled() );
+    checkForBetaVersionCheckBox->setEnabled( config.versionCheckingEnabled() );
 
     // downloads
     verifySslCheckBox->setChecked( config.verifySslPeers() );
@@ -548,6 +554,7 @@ void OptionsDialog::updateConfigFromDialog()
 
     // version checking
     config.setVersionCheckingEnabled( checkForNewVersionCheckBox->isChecked() );
+    config.setBetaVersionCheckingEnabled( checkForBetaVersionCheckBox->isChecked() );
 
     config.setVerifySslPeers( verifySslCheckBox->isChecked() );
 

--- a/src/versioncheck/src/versionchecker.cpp
+++ b/src/versioncheck/src/versionchecker.cpp
@@ -109,22 +109,25 @@ void VersionChecker::startCheck()
     const auto& deadlineConfig = VersionCheckerConfig::getSynced();
     const auto& appConfig = Configuration::get();
 
-    if ( appConfig.versionCheckingEnabled() ) {
-        // Check the deadline has been reached
-        if ( deadlineConfig.nextDeadline() < std::time( nullptr ) ) {
-            connect( manager_, &QNetworkAccessManager::finished, this,
-                     &VersionChecker::downloadFinished );
+    if ( !appConfig.versionCheckingEnabled() ) {
+        return;
+    }
 
-            LOG_DEBUG << "Requesting new version info from " << VERSION_URL;
+    // Beta checks bypass the 7-day deadline and run on every app start
+    const bool deadlineReached = deadlineConfig.nextDeadline() < std::time( nullptr );
+    if ( deadlineReached || appConfig.betaVersionCheckingEnabled() ) {
+        connect( manager_, &QNetworkAccessManager::finished, this,
+                 &VersionChecker::downloadFinished );
 
-            QNetworkRequest request;
-            request.setUrl( QUrl( VERSION_URL ) );
-            manager_->get( request );
-        }
-        else {
-            LOG_DEBUG << "Deadline not reached yet, next check in "
-                      << std::difftime( deadlineConfig.nextDeadline(), std::time( nullptr ) );
-        }
+        LOG_DEBUG << "Requesting new version info from " << VERSION_URL;
+
+        QNetworkRequest request;
+        request.setUrl( QUrl( VERSION_URL ) );
+        manager_->get( request );
+    }
+    else {
+        LOG_DEBUG << "Deadline not reached yet, next check in "
+                  << std::difftime( deadlineConfig.nextDeadline(), std::time( nullptr ) );
     }
 }
 
@@ -159,15 +162,32 @@ void VersionChecker::checkVersionData( QByteArray versionData )
 
     QString latestVersion;
     QString url;
+    bool isBetaNotification = false;
     const auto stableVersions = latestVersionMap.value( "releases" ).toList();
 
     const auto currentVersion = logsquirlVersion();
-    if ( std::any_of( stableVersions.begin(), stableVersions.end(),
-                      [ &currentVersion ]( const auto& version ) {
-                          return version.toString() == currentVersion;
-                      } ) ) {
+    const bool isStableUser = std::any_of(
+        stableVersions.begin(), stableVersions.end(),
+        [ &currentVersion ]( const auto& version ) {
+            return version.toString() == currentVersion;
+        } );
+
+    if ( isStableUser ) {
         latestVersion = latestVersionMap.value( "stable" ).toString();
         url = latestVersionMap.value( "stable_url" ).toString();
+
+        // If no newer stable version, check for beta when user opted in
+        const auto& appConfig = Configuration::get();
+        if ( !isVersionNewer( currentVersion, latestVersion )
+             && appConfig.betaVersionCheckingEnabled() ) {
+            const auto betaVersion = latestVersionMap.value( "beta" ).toString();
+            const auto betaUrl = latestVersionMap.value( "beta_url" ).toString();
+            if ( !betaVersion.isEmpty() && isVersionNewer( currentVersion, betaVersion ) ) {
+                latestVersion = betaVersion;
+                url = betaUrl;
+                isBetaNotification = true;
+            }
+        }
     }
     else {
         latestVersion = latestVersionMap.value( "ci" ).toString();
@@ -177,7 +197,7 @@ void VersionChecker::checkVersionData( QByteArray versionData )
     const auto changeLog = latestVersionMap.value( "changelog" ).toList();
 
     QStringList changes;
-    for ( const auto& entry :  changeLog ) {
+    for ( const auto& entry : changeLog ) {
         const auto entryData = entry.toMap();
         const auto version = entryData.value( "version" ).toString();
 
@@ -188,10 +208,13 @@ void VersionChecker::checkVersionData( QByteArray versionData )
     }
 
     LOG_DEBUG << "Current version: " << currentVersion << ". Latest version is " << latestVersion
-              << ", url " << url;
+              << ", url " << url << ( isBetaNotification ? " (beta)" : "" );
     if ( isVersionNewer( currentVersion, latestVersion ) ) {
-        LOG_INFO << "Sending new version notification";
+        LOG_INFO << "Sending new version notification"
+                 << ( isBetaNotification ? " (beta)" : "" );
 
-        Q_EMIT newVersionFound( latestVersion, url, changes );
+        const auto displayVersion
+            = isBetaNotification ? QString( "%1 (Beta)" ).arg( latestVersion ) : latestVersion;
+        Q_EMIT newVersionFound( displayVersion, url, changes );
     }
 }


### PR DESCRIPTION
Add a 'Check for beta updates' checkbox to Settings > General that lets stable users opt in to beta version notifications. Beta checks bypass the 7-day deadline and run on every application start.

Changes:
- latest.json: add beta/beta_url fields
- Configuration: add betaVersionCheckingEnabled setting with persistence
- OptionsDialog: add checkbox, disabled when version checking is off
- VersionChecker: bypass deadline for beta, check beta field from JSON, label notifications with (Beta) suffix
- ci-release.yml: add beta-tag input to create beta GitHub releases and auto-update latest.json