### PR TITLE
ci: pre-seed CPM cache to prevent DNS failures in sub-projects

### DIFF
--- a/.github/actions/agent-build/action.yml
+++ b/.github/actions/agent-build/action.yml
@@ -10,6 +10,12 @@ runs:
         echo "CC=${{ matrix.config.cc }}" >> $GITHUB_ENV
         echo "CXX=${{ matrix.config.cxx }}" >> $GITHUB_ENV
 
+    - name: Pre-seed CPM for sub-projects
+      shell: sh
+      run: |
+        mkdir -p $LOGSQUIRL_WORKSPACE/cpm_cache/cpm
+        cp $LOGSQUIRL_WORKSPACE/cmake/CPM.cmake $LOGSQUIRL_WORKSPACE/cpm_cache/cpm/CPM_0.38.6.cmake
+
     - name: configure
       shell: sh
       run: |

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -3,6 +3,12 @@ description: "Generate the build files, build the code and run the tests"
 runs:
   using: "composite"
   steps:
+    - name: Pre-seed CPM for sub-projects
+      shell: sh
+      run: |
+        mkdir -p "$LOGSQUIRL_WORKSPACE/cpm_cache/cpm"
+        cp "$LOGSQUIRL_WORKSPACE/cmake/CPM.cmake" "$LOGSQUIRL_WORKSPACE/cpm_cache/cpm/CPM_0.38.6.cmake"
+
     - name: configure
       shell: sh
       run: |


### PR DESCRIPTION
CRoaring v4.2.1 bundles its own CPM bootstrap that downloads CPM v0.38.6 from GitHub. On macOS runners with intermittent DNS issues this download fails, breaking the entire cmake configure.

Pre-seed the CPM source cache with our project's CPM.cmake at the path CRoaring expects, so the bootstrap skips the download.