### PR TITLE
docs: update documentation and website for 26.03 beta release

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -168,6 +168,12 @@ or simple text search.
 It is possible to save the current search pattern as a predefined filter from
 search input context menu.
 
+### Importing filters from Chipmunk
+
+*logsquirl* can import filters and highlighters from Chipmunk JSON export files.
+This is available from the `Tools` menu. The imported filters are converted to
+*logsquirl* predefined filters and highlighter sets.
+
 ### Using highlighters
 
 *Highlighters* can colorize some lines of the log being displayed
@@ -250,15 +256,34 @@ The following file mode requires monitoring of the file system for any changes.
 If native monitoring or polling are both disabled in settings, then the 
 following file mode is also disabled.
 
+### Filters Panel
+
+The Filters Panel is a right sidebar dock that provides quick access to filters
+and the Scratchpad. It contains two tabs:
+
+*   **Filters tab** -- allows pinning frequently used search filters that persist
+    across sessions. Toggling a pinned filter automatically triggers a search.
+*   **Scratchpad tab** -- the same Scratchpad tool described below, accessible
+    from the sidebar for convenience.
+
+The Filters Panel can be toggled using the filter icon in the toolbar.
+
 ### Scratchpad
 
 Sometimes in log files there are text in base64 encoding, unformatted
 xml/json, etc. For such cases *logsquirl* provides Scratchpad tool. Text can
 be copied to this window and transformed to human-readable form.
 Use context menu to either add data to the current scratchpad tab or 
-replace its content with selected text. There are shortcuts `Ctrl+Z` and `Ctrl+Shit+Z` for these actions.
+replace its content with selected text. There are shortcuts `Ctrl+Z` and `Ctrl+Shift+Z` for these actions.
 
 New tabs can be opened in Scratchpad using the `Ctrl+N` hotkey.
+
+#### JWT token decoder
+
+The Scratchpad includes a JWT (JSON Web Token) decoder. When a JWT is pasted
+into the Scratchpad, it can decode the Base64URL-encoded header and payload,
+format the JSON with indentation, and annotate epoch timestamp fields
+(`iat`, `exp`, `nbf`, `auth_time`) with human-readable UTC dates.
 
 ## Settings
 
@@ -312,6 +337,10 @@ once per week.
 
 Stable builds will check if a new stable version is available and pop a dialogue about it.
 Testing builds will check for new testing versions.
+
+There is also an opt-in beta update channel. When "Check for beta updates" is enabled,
+*logsquirl* checks for beta versions on every startup (bypassing the 7-day interval)
+and shows notifications with a "(Beta)" label.
 
 ### View
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ LogSquirl is standing on the shoulders of giants.
 * Includes a dark mode
 * Has configurable shortcuts
 * Has a scratchpad window for taking notes and doing basic data transformations
+* Includes a JWT token decoder in the Scratchpad for inspecting JSON Web Tokens
+* Features a Filters Panel with pinned filters that persist across sessions
+* Can import filters and highlighters from Chipmunk JSON export files
+* Offers an opt-in beta update channel for early access to new versions
 * Open source, released under the GPL-3.0
 
 **[Back to top](#table-of-contents)**

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -5,7 +5,7 @@ type: docs
 
 ## Faster log explorer
 
-_logsquirl_ is an open source multi-platform GUI application to search through all kinds of text log files using regular expressions. It has started as fork of [glogg project](https://glogg.bonnefon.org/) created by [Nicolas Bonnefon](https://github.com/nickbnf), and has evolved into a separate project with a lot of new features and improvements.
+_logsquirl_ is an open source multi-platform GUI application to search through all kinds of text log files using regular expressions. It started as a fork of [klogg](https://github.com/variar/klogg) by [Anton Filimonov](https://github.com/variar), which itself was a fork of the [glogg project](https://glogg.bonnefon.org/) by [Nicolas Bonnefon](https://github.com/nickbnf). Since the original klogg is no longer actively maintained, _logsquirl_ continues development under a new name with many new features and improvements.
 
 _logsquirl_ is designed to:
 
@@ -24,9 +24,9 @@ Here is what _logsquirl_ looks like:
 
 ## Features
 {{< columns >}}
- _logsquirl_ inherited a lot of features from _glogg_
+ _logsquirl_ inherited a lot of features from _glogg_ and _klogg_
 
- - Runs on Unix-like systems, Windows and Mac thanks to Qt5
+ - Runs on Unix-like systems, Windows and Mac thanks to Qt
  - Displays search results separately from original file
  - Supports Perl-compatible regular expressions
  - Colorizes the log and search results
@@ -42,7 +42,12 @@ _logsquirl_ improves and brings more
  - Has portable version (no need to install)
  - Understands a lot of text encodings and detects many of them automatically
  - Allows to perform search in a portion of huge log file
+ - Combines regular expressions with boolean operators (AND, OR, NOT)
  - Supports multiple sets of text highlight rules with more sophisticated match options
+ - Includes a Filters Panel with pinned filters that persist across sessions
+ - JWT token decoder in Scratchpad for inspecting JSON Web Tokens
+ - Import filters and highlighters from Chipmunk JSON export files
+ - Opt-in beta update channel for early access to new versions
  - Provides many small features to make life easier (tab renaming, favorite files list, archive extraction,
  scratchpad etc.)
  
@@ -51,11 +56,9 @@ _logsquirl_ improves and brings more
 
 ## Downloads
 
-Latest stable version:
+Latest beta version:
 
 [ ![GitHub Release](https://img.shields.io/github/v/release/64x-lunicorn/LogSquirl?label=GitHub%20Release&style=for-the-badge)](https://github.com/64x-lunicorn/LogSquirl/releases/latest)
-[ ![Chocolatey](https://img.shields.io/chocolatey/v/logsquirl?style=for-the-badge)](https://chocolatey.org/packages/logsquirl)
-[ ![Homebrew](https://img.shields.io/homebrew/cask/v/logsquirl?style=for-the-badge)](https://formulae.brew.sh/cask/logsquirl)
 
 
 Latest development builds can be downloaded from releases on Github: 

--- a/website/content/docs/getting_involved/_index.md
+++ b/website/content/docs/getting_involved/_index.md
@@ -11,10 +11,8 @@ Feel free to submit bug reports, feature requests, questions and pull requests o
 There is a [Discord server](https://discord.gg/DruNyQftzB), [Telegram group](https://t.me/joinchat/JeIBxstIfp4xZTk6) 
 and [Gitter community](https://gitter.im/logsquirl_log_viewer/community).
 
-## Mailing list
-_glogg_ has a mailing list where bugs, features and future development are discussed. Sometimes these ideas end up in _logsquirl_ earlier.
-
-The mailing list address is glogg-devel@googlegroups.com and the archive is found on [Google Groups](http://groups.google.co.uk/group/glogg-devel).
+## Historical mailing list
+The original _glogg_ project had a mailing list (glogg-devel@googlegroups.com) where bugs, features and future development were discussed. The archive can still be found on [Google Groups](http://groups.google.co.uk/group/glogg-devel). For _logsquirl_ development, please use GitHub, Discord, Telegram, or Gitter instead.
 
 ## Sponsors
 Big thanks to everyone sponsoring _logsquirl_. This helps running code-signing infrastructure

--- a/website/content/docs/news/release_26.03.md
+++ b/website/content/docs/news/release_26.03.md
@@ -1,0 +1,42 @@
+---
+title: "Version 26.03 (Beta)"
+date: 2025-06-01T00:00:00+00:00
+anchor: "v26_03"
+weight: 26
+---
+
+## Version 26.03 (Beta)
+
+This is the first release of **LogSquirl**, a GPL-3.0 fork of [klogg](https://github.com/variar/klogg). Since klogg is no longer actively maintained, LogSquirl continues development under a new name, building on the excellent foundation laid by both glogg and klogg.
+
+### New features
+ - **Rebranded** from klogg to LogSquirl with new bundle identifier `io.github.logsquirl`
+ - **JWT token decoder** in Scratchpad: decodes Base64URL header and payload, formats JSON with indentation, and annotates epoch timestamps (`iat`, `exp`, `nbf`, `auth_time`) with human-readable UTC dates
+ - **Filters Panel**: right sidebar dock with tabbed Filters and Scratchpad panels, toolbar filter icon, auto-search on toggle, and pinned filters that persist across sessions
+ - **Chipmunk filter import**: import filters and highlighters from Chipmunk JSON export files via the Tools menu
+ - **Beta update channel**: opt-in "Check for beta updates" checkbox in Settings > General. When enabled, the app checks for beta versions on every startup (bypassing the 7-day interval) and shows notifications with "(Beta)" label
+
+### Bug fixes
+ - Fixed crash on shutdown with Qt 6.10 on Windows (QThreadPool::waitForDone SEGFAULT)
+ - Fixed BOM not written when saving search results to file for UTF-16 encoded logs
+ - Upgraded OpenSSL from 1.1.x to 3.x (CVE-2022-1292)
+
+### Build system
+ - Upgraded to Qt 6.10.3 as primary build target (Qt 5 still supported)
+ - Added CPM dependency management
+ - Added Fedora 43 and Oracle Linux 10 build targets
+ - Upgraded robin_hood to 3.11.5 with GCC 14 compatibility patch
+ - Replaced unreliable AppleScript DMG layout with pre-built DS_Store file
+ - Fixed macOS Gatekeeper rejection by signing each nested component individually with hardened-runtime entitlements
+
+### CI/CD modernization
+ - Pre-built Docker images on GHCR for reproducible builds
+ - Tag-based releases (stable + beta), single release per tag with all platforms bundled
+ - Upgraded CI runners: macOS 15 (ARM + Intel), Windows 2025, Ubuntu 24.04
+ - Non-blocking Sentry/CodeQL jobs, reusable build workflow via `workflow_call`
+ - Auto-changelog generation via `scripts/gen_changelog.py`
+
+### System requirements
+LogSquirl requires a CPU with at least SSE2 instruction set. For best performance, the CPU should have SSSE3 and POPCNT instructions.
+
+Supported operating systems: Windows 10+, macOS 12+, Ubuntu 22.04+, Fedora 43+, Oracle Linux 10+

--- a/website/content/docs/privacy_policy/_index.md
+++ b/website/content/docs/privacy_policy/_index.md
@@ -49,7 +49,7 @@ Except as described above, and as required to perform the application's core fun
 ### Questions and Feedback
 Our privacy policies might change or be edited for clarity over time. Up-to-date information will always be available from this page.
 
-Please [contact us](https://github.com/vairar) if you have any questions about our data collection or privacy policies. We'll be more than happy to discuss them with you.
+Please [contact us](https://github.com/64x-lunicorn/LogSquirl/issues) if you have any questions about our data collection or privacy policies. We'll be more than happy to discuss them with you.
  
  
 

--- a/website/themes/hugo-book/layouts/partials/docs/inject/body.html
+++ b/website/themes/hugo-book/layouts/partials/docs/inject/body.html
@@ -4,27 +4,9 @@
 <script type="text/javascript" src="//www.FreePrivacyPolicy.com/cookie-consent/releases/3.0.0/cookie-consent.js"></script>
 <script type="text/javascript">
 document.addEventListener('DOMContentLoaded', function () {
-    cookieconsent.run({"notice_banner_type":"simple","consent_type":"implied","palette":"light","change_preferences_selector":"#changePreferences","language":"en","website_name":"klogg"});
+    cookieconsent.run({"notice_banner_type":"simple","consent_type":"implied","palette":"light","change_preferences_selector":"#changePreferences","language":"en","website_name":"LogSquirl"});
 });
 </script>
-
-<!-- Yandex Metrika -->
-<!-- Yandex.Metrika counter -->
-<script type="text/plain" cookie-consent="tracking" >
-    (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-    m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-    (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
- 
-    ym(55695499, "init", {
-         clickmap:true,
-         trackLinks:true,
-         accurateTrackBounce:true
-    });
- </script>
- <noscript><div><img src="https://mc.yandex.ru/watch/55695499" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
- <!-- /Yandex.Metrika counter -->
-
-<!-- end of Yandex Metrika-->
 
 <noscript>GDPR Cookie Consent by <a href="https://www.freeprivacypolicy.com/">Free Privacy Policy</a></noscript>
 <!-- End Cookie Consent -->

--- a/website/themes/hugo-book/layouts/partials/docs/inject/menu-after.html
+++ b/website/themes/hugo-book/layouts/partials/docs/inject/menu-after.html
@@ -2,8 +2,8 @@
     <hr />
 
     <li>
-        <a href="https://github.com/variar/glogg">
-            <i class="fab fa-github fa-lg"></i> klogg on GitHub
+        <a href="https://github.com/64x-lunicorn/LogSquirl">
+            <i class="fab fa-github fa-lg"></i> LogSquirl on GitHub
         </a>
     </li>
 
@@ -20,39 +20,6 @@
                 <a href="https://github.com/64x-lunicorn/LogSquirl/releases/latest">
                     <img src="https://img.shields.io/github/v/release/64x-lunicorn/LogSquirl?label=GitHub%20Release&amp;style=for-the-badge"
                         alt="GitHub Release">
-                </a>
-            </li>
-
-            <li>
-                <a href="https://formulae.brew.sh/cask/klogg">
-                    <img src="https://img.shields.io/homebrew/cask/v/klogg?style=for-the-badge" alt="Homebrew">
-                </a>
-            </li>
-
-            <li>
-                <a href="https://chocolatey.org/packages/klogg">
-                    <img src="https://img.shields.io/chocolatey/v/klogg?style=for-the-badge" alt="Chocolatey">
-                </a>
-            </li>
-        </ul>
-    </li>
-
-    <li class="book-section-flat">
-        <span>Development builds</span>
-        <ul>
-            <li>
-                <a href="https://github.com/64x-lunicorn/LogSquirl/releases/tag/continuous-win" target="_blank">
-                    <i class="fab fa-windows fa-lg"></i> Windows
-                </a>
-            </li>
-            <li>
-                <a href="https://github.com/64x-lunicorn/LogSquirl/releases/tag/continuous-linux" target="_blank">
-                    <i class="fab fa-linux fa-lg"></i> Linux
-                </a>
-            </li>
-            <li>
-                <a href="https://github.com/64x-lunicorn/LogSquirl/releases/tag/continuous-osx" target="_blank">
-                    <i class="fab fa-apple fa-lg"></i> Mac
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
- Update website homepage: clarify glogg/klogg/LogSquirl lineage, fix Qt5 reference, add new features (JWT decoder, Filters Panel, Chipmunk import, beta update channel) to feature list
- Fix website sidebar: update GitHub link from variar/glogg to LogSquirl, remove stale Homebrew/Chocolatey badges (packages not yet published), remove obsolete continuous-win/linux/osx dev build links
- Remove Yandex Metrika tracking (belonged to old klogg project)
- Fix cookie consent website_name from klogg to LogSquirl
- Fix broken contact link in privacy policy (vairar typo to LogSquirl issues)
- Update getting_involved: mark glogg mailing list as historical, emphasize Discord/Telegram/Gitter as primary channels
- Add release announcement page for version 26.03 (Beta)
- Update DOCUMENTATION.md: add Filters Panel section, JWT decoder in Scratchpad, Chipmunk filter import, beta update channel option
- Update README.md: add new 26.03 features to feature list