### PR TITLE
fix: prevent UI hang on log files with excessive tab characters

### DIFF
--- a/src/logdata/include/linetypes.h
+++ b/src/logdata/include/linetypes.h
@@ -306,21 +306,80 @@ private:
 // Length of a tab stop
 constexpr int TabStop = 8;
 
+// Maximum expanded line length for display (prevents OOM on malicious/corrupt files).
+// Lines exceeding this after tab expansion are truncated.
+constexpr int MaxExpandedLineLength = 1'000'000;
+
+// Replaces tab characters with the appropriate number of spaces using O(n) single-pass
+// algorithm. Also replaces null characters with spaces.
 inline QString untabify( QString&& line, LineColumn initialPosition = 0_lcol )
 {
-    line.replace( QChar::Null, QChar::Space );
+    const auto* src = line.constData();
+    const auto srcLen = static_cast<int>( line.size() );
 
-    LineLength::UnderlyingType position = 0;
-    position = type_safe::narrow_cast<LineLength::UnderlyingType>(
-        line.indexOf( QChar::Tabulation, position ) );
-    while ( position >= 0 ) {
-        const auto spaces = TabStop - ( ( initialPosition.get() + position ) % TabStop );
-        line.replace( position, 1, QString( spaces, QChar::Space ) );
-        position = type_safe::narrow_cast<LineLength::UnderlyingType>(
-            line.indexOf( QChar::Tabulation, position ) );
+    // Fast path: no tabs and no nulls — return as-is
+    bool hasTabs = false;
+    bool hasNulls = false;
+    for ( int i = 0; i < srcLen; ++i ) {
+        if ( src[ i ] == QChar::Tabulation ) {
+            hasTabs = true;
+            break;
+        }
+        if ( src[ i ] == QChar::Null ) {
+            hasNulls = true;
+        }
     }
 
-    return std::move( line );
+    if ( !hasTabs ) {
+        if ( hasNulls ) {
+            line.replace( QChar::Null, QChar::Space );
+        }
+        return std::move( line );
+    }
+
+    // First pass: compute expanded length
+    int expandedLen = 0;
+    int column = initialPosition.get<int>();
+    for ( int i = 0; i < srcLen; ++i ) {
+        if ( src[ i ] == QChar::Tabulation ) {
+            const int spaces = TabStop - ( column % TabStop );
+            expandedLen += spaces;
+            column += spaces;
+        }
+        else {
+            ++expandedLen;
+            ++column;
+        }
+    }
+
+    // Cap at maximum display length to prevent OOM
+    const bool truncated = expandedLen > MaxExpandedLineLength;
+    if ( truncated ) {
+        expandedLen = MaxExpandedLineLength;
+    }
+
+    // Second pass: build result string in one allocation
+    QString result;
+    result.reserve( expandedLen );
+
+    column = initialPosition.get<int>();
+    int outPos = 0;
+    for ( int i = 0; i < srcLen && outPos < expandedLen; ++i ) {
+        if ( src[ i ] == QChar::Tabulation ) {
+            const int spaces = TabStop - ( column % TabStop );
+            const int toWrite = std::min( spaces, expandedLen - outPos );
+            result.append( QString( toWrite, QChar::Space ) );
+            column += spaces;
+            outPos += toWrite;
+        }
+        else {
+            result.append( src[ i ] == QChar::Null ? QChar::Space : src[ i ] );
+            ++column;
+            ++outPos;
+        }
+    }
+
+    return result;
 }
 
 template <typename LineType>
@@ -336,6 +395,32 @@ LineLength getUntabifiedLength( const LineType& utf8Line )
         tabPosition = utf8Line.find( '\t', tabPosition + 1 );
     }
 
-    return LineLength( type_safe::narrow_cast<LineLength::UnderlyingType>(
-        static_cast<int64_t>( utf8Line.size() + totalSpaces ) ) );
+    const auto expandedLen = static_cast<int64_t>( utf8Line.size() + totalSpaces );
+    const auto cappedLen = std::min( expandedLen, static_cast<int64_t>( MaxExpandedLineLength ) );
+
+    return LineLength( type_safe::narrow_cast<LineLength::UnderlyingType>( cappedLen ) );
+}
+
+// Calculates the expanded length of a QString after tab expansion, without allocating
+// a new string. O(n) in the length of the input.
+inline LineLength getUntabifiedLength( const QString& line )
+{
+    const auto* src = line.constData();
+    const auto srcLen = static_cast<int>( line.size() );
+    int expandedLen = 0;
+    int column = 0;
+
+    for ( int i = 0; i < srcLen; ++i ) {
+        if ( src[ i ] == QChar::Tabulation ) {
+            const int spaces = TabStop - ( column % TabStop );
+            expandedLen += spaces;
+            column += spaces;
+        }
+        else {
+            ++expandedLen;
+            ++column;
+        }
+    }
+
+    return LineLength( std::min( expandedLen, MaxExpandedLineLength ) );
 }

--- a/src/logdata/src/logdata.cpp
+++ b/src/logdata/src/logdata.cpp
@@ -274,7 +274,8 @@ LineLength LogData::doGetLineLength( LineNumber line ) const
         return 0_length; /* exception? */
     }
 
-    return LineLength{ doGetExpandedLineString( line ).size() };
+    // Use allocation-free length calculation instead of building the full expanded string
+    return getUntabifiedLength( doGetLineString( line ) );
 }
 
 void LogData::doSetDisplayEncoding( const char* encoding )

--- a/src/ui/src/highlighterset.cpp
+++ b/src/ui/src/highlighterset.cpp
@@ -277,6 +277,12 @@ HighlighterMatchType HighlighterSet::matchLine( const QString& line,
         return HighlighterMatchType::NoMatch;
     }
 
+    // Skip expensive regex matching on extremely long lines to prevent UI hangs
+    constexpr int MaxHighlightLineLength = 1'000'000;
+    if ( line.size() > MaxHighlightLineLength ) {
+        return HighlighterMatchType::NoMatch;
+    }
+
     if ( !compiledExpression_ ) {
         compile();
     }

--- a/tests/e2e/test_heavy_tabs.py
+++ b/tests/e2e/test_heavy_tabs.py
@@ -1,0 +1,122 @@
+"""
+E2E tests for files with extremely heavy tab usage.
+
+Validates that LogSquirl handles log files containing lines with
+thousands or tens of thousands of tab characters without hanging
+or crashing — the scenario from tmp/stderr.log (ASAN crash dump
+with ~37 million tabs on one line).
+
+The test file test_data/heavy_tabs_crash.log is a representative
+smaller version with 50,000 tabs on a single line.
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from conftest import grep_output_lines, measure_execution, run_grep, run_gui
+
+
+class TestGrepHeavyTabs:
+    """Verify logsquirl_grep handles files with massive tab counts."""
+
+    def test_grep_heavy_tabs_completes(self, logsquirl_grep_binary, test_data_dir):
+        """Grep on a file with 50k tabs must complete within the timeout (no hang)."""
+        filepath = test_data_dir / "heavy_tabs_crash.log"
+        result = run_grep(logsquirl_grep_binary, "asan", filepath, timeout=10)
+        assert result.returncode == 0
+
+    def test_grep_heavy_tabs_finds_match(self, logsquirl_grep_binary, test_data_dir):
+        """Grep must find the line containing 'asan' even though it has 50k tabs."""
+        filepath = test_data_dir / "heavy_tabs_crash.log"
+        result = run_grep(logsquirl_grep_binary, "asan", filepath, timeout=10)
+        lines = grep_output_lines(result)
+        assert any("asan" in l for l in lines), f"Expected 'asan' in output, got: {lines}"
+
+    def test_grep_heavy_tabs_matches_normal_lines(self, logsquirl_grep_binary, test_data_dir):
+        """Grep for a pattern on normal (non-tabbed) lines still works."""
+        filepath = test_data_dir / "heavy_tabs_crash.log"
+        result = run_grep(logsquirl_grep_binary, "AvpCore", filepath, timeout=10)
+        lines = grep_output_lines(result)
+        assert any("AvpCore" in l for l in lines)
+
+    def test_grep_heavy_tabs_dot_pattern(self, logsquirl_grep_binary, test_data_dir):
+        """'.' pattern (match all) must not hang on the heavy tabs file."""
+        filepath = test_data_dir / "heavy_tabs_crash.log"
+        result = run_grep(logsquirl_grep_binary, ".", filepath, timeout=10)
+        assert result.returncode == 0
+        lines = grep_output_lines(result)
+        # File has 6 lines
+        assert len(lines) == 6
+
+
+class TestGrepHeavyTabsPerformance:
+    """Verify grep on heavy-tab files completes quickly (no quadratic blowup)."""
+
+    def test_grep_heavy_tabs_under_2_seconds(self, logsquirl_grep_binary, test_data_dir):
+        """Grep for '.' on heavy_tabs_crash.log must complete in under 2 seconds."""
+        filepath = test_data_dir / "heavy_tabs_crash.log"
+
+        def search():
+            run_grep(logsquirl_grep_binary, ".", filepath, timeout=5)
+
+        result = measure_execution(search, warmup=1, runs=3)
+        assert result["median_seconds"] < 2.0, (
+            f"Grep on heavy tabs file took {result['median_seconds']:.3f}s "
+            f"(expected < 2.0s — possible quadratic tab expansion regression)"
+        )
+
+
+class TestGuiHeavyTabs:
+    """Verify the GUI does not hang or crash when opening heavy-tab files."""
+
+    def test_gui_open_heavy_tabs_no_crash(self, logsquirl_binary, test_data_dir):
+        """Opening the heavy tabs file in the GUI must not crash or hang."""
+        test_file = test_data_dir / "heavy_tabs_crash.log"
+        try:
+            proc = subprocess.Popen(
+                [str(logsquirl_binary), "-n", str(test_file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            # Give it time to index and try to render — old code would hang here
+            time.sleep(5)
+            proc.terminate()
+            proc.wait(timeout=5)
+            # Should not have segfaulted (-11) or aborted (-6)
+            assert proc.returncode not in (-11, -6, 139, 134), (
+                f"GUI crashed with exit code {proc.returncode} on heavy tabs file"
+            )
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            pytest.fail("GUI hung when opening heavy_tabs_crash.log (did not respond to SIGTERM)")
+
+
+class TestGrepSyntheticHeavyTabs:
+    """Test with dynamically generated files of varying tab density."""
+
+    def test_grep_100k_tabs_single_line(self, logsquirl_grep_binary, tmp_path):
+        """A file with 100,000 tabs on one line must not hang grep."""
+        test_file = tmp_path / "100k_tabs.log"
+        test_file.write_text("normal line\n" + "\t" * 100_000 + "marker\n" + "end\n")
+
+        result = run_grep(logsquirl_grep_binary, "marker", test_file, timeout=10)
+        assert result.returncode == 0
+        lines = grep_output_lines(result)
+        assert any("marker" in l for l in lines)
+
+    def test_grep_many_lines_with_tabs(self, logsquirl_grep_binary, tmp_path):
+        """A file with 1000 lines each having 100 tabs must complete quickly."""
+        test_file = tmp_path / "many_tab_lines.log"
+        content = ""
+        for i in range(1000):
+            content += f"line{i}" + "\t" * 100 + f"end{i}\n"
+        test_file.write_text(content)
+
+        result = run_grep(logsquirl_grep_binary, "end500", test_file, timeout=10)
+        assert result.returncode == 0
+        lines = grep_output_lines(result)
+        assert any("end500" in l for l in lines)

--- a/tests/unit/linetypes_test.cpp
+++ b/tests/unit/linetypes_test.cpp
@@ -332,3 +332,219 @@ SCENARIO( "LineNumber compared with LinesCount", "[linetypes]" )
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// untabify() tests
+// ---------------------------------------------------------------------------
+
+SCENARIO( "untabify expands tabs to spaces correctly", "[linetypes][untabify]" )
+{
+    GIVEN( "A string with no tabs" )
+    {
+        QString input = "hello world";
+
+        THEN( "It is returned unchanged" )
+        {
+            auto result = untabify( QString( input ) );
+            REQUIRE( result == "hello world" );
+        }
+    }
+
+    GIVEN( "An empty string" )
+    {
+        THEN( "It returns empty" )
+        {
+            auto result = untabify( QString( "" ) );
+            REQUIRE( result.isEmpty() );
+        }
+    }
+
+    GIVEN( "A single tab at position 0" )
+    {
+        THEN( "It expands to 8 spaces (TabStop)" )
+        {
+            auto result = untabify( QString( "\t" ) );
+            REQUIRE( result == QString( 8, QChar::Space ) );
+            REQUIRE( result.size() == TabStop );
+        }
+    }
+
+    GIVEN( "A tab after 3 characters" )
+    {
+        THEN( "It expands to 5 spaces (next tab stop at 8)" )
+        {
+            auto result = untabify( QString( "abc\t" ) );
+            REQUIRE( result == "abc     " );
+            REQUIRE( result.size() == 8 );
+        }
+    }
+
+    GIVEN( "A tab at an exact tab stop boundary" )
+    {
+        // 8 chars + tab → tab at column 8 → next stop is 16, so 8 spaces
+        THEN( "It expands to a full TabStop width" )
+        {
+            auto result = untabify( QString( "12345678\t" ) );
+            REQUIRE( result == "12345678        " );
+            REQUIRE( result.size() == 16 );
+        }
+    }
+
+    GIVEN( "Multiple consecutive tabs" )
+    {
+        THEN( "Each tab respects its own column position" )
+        {
+            auto result = untabify( QString( "\t\t" ) );
+            REQUIRE( result.size() == 16 );
+            REQUIRE( result == QString( 16, QChar::Space ) );
+        }
+    }
+
+    GIVEN( "Mixed text and tabs" )
+    {
+        THEN( "Tab stops align correctly" )
+        {
+            // "ab\tcd\tefgh"
+            // 'a' at 0, 'b' at 1, tab at 2 → 6 spaces → "ab      "
+            // 'c' at 8, 'd' at 9, tab at 10 → 6 spaces → "cd      "
+            // 'e' at 16, 'f' at 17, 'g' at 18, 'h' at 19
+            auto result = untabify( QString( "ab\tcd\tefgh" ) );
+            REQUIRE( result == "ab      cd      efgh" );
+            REQUIRE( result.size() == 20 );
+        }
+    }
+
+    GIVEN( "A string with null characters" )
+    {
+        THEN( "Nulls are replaced with spaces" )
+        {
+            QString input;
+            input.append( 'a' );
+            input.append( QChar::Null );
+            input.append( 'b' );
+            auto result = untabify( std::move( input ) );
+            REQUIRE( result == "a b" );
+        }
+    }
+
+    GIVEN( "An initialPosition offset" )
+    {
+        THEN( "Tab stops align relative to the initial column" )
+        {
+            // initialPosition=3, tab at pos 0 → column 3 → spaces = 8 - (3 % 8) = 5
+            auto result = untabify( QString( "\t" ), LineColumn( 3 ) );
+            REQUIRE( result.size() == 5 );
+        }
+    }
+}
+
+SCENARIO( "untabify handles very long lines with many tabs efficiently", "[linetypes][untabify]" )
+{
+    GIVEN( "A line with 10000 tabs" )
+    {
+        QString input( 10'000, QChar::Tabulation );
+
+        THEN( "It completes and produces the correct length" )
+        {
+            auto result = untabify( std::move( input ) );
+            REQUIRE( result.size() == 10'000 * TabStop );
+        }
+    }
+
+    GIVEN( "A line with tabs that would exceed MaxExpandedLineLength" )
+    {
+        // Each tab at position 0 of its group expands to 8 spaces.
+        // Need > MaxExpandedLineLength / 8 tabs to trigger truncation.
+        const int numTabs = ( MaxExpandedLineLength / TabStop ) + 1000;
+        QString input( numTabs, QChar::Tabulation );
+
+        THEN( "It is capped at MaxExpandedLineLength" )
+        {
+            auto result = untabify( std::move( input ) );
+            REQUIRE( result.size() == MaxExpandedLineLength );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// getUntabifiedLength() tests
+// ---------------------------------------------------------------------------
+
+SCENARIO( "getUntabifiedLength calculates correct expanded length", "[linetypes][untabify]" )
+{
+    GIVEN( "A string with no tabs" )
+    {
+        std::string input = "hello";
+
+        THEN( "Length equals the string size" )
+        {
+            REQUIRE( getUntabifiedLength( input ).get() == 5 );
+        }
+    }
+
+    GIVEN( "An empty string" )
+    {
+        THEN( "Length is zero" )
+        {
+            REQUIRE( getUntabifiedLength( std::string( "" ) ).get() == 0 );
+        }
+    }
+
+    GIVEN( "A single tab at position 0" )
+    {
+        THEN( "Length equals TabStop" )
+        {
+            REQUIRE( getUntabifiedLength( std::string( "\t" ) ).get() == TabStop );
+        }
+    }
+
+    GIVEN( "Tab after 3 characters" )
+    {
+        THEN( "Length is 8 (3 chars + 5 spaces)" )
+        {
+            REQUIRE( getUntabifiedLength( std::string( "abc\t" ) ).get() == 8 );
+        }
+    }
+
+    GIVEN( "Two consecutive tabs" )
+    {
+        THEN( "Length is 16" )
+        {
+            REQUIRE( getUntabifiedLength( std::string( "\t\t" ) ).get() == 16 );
+        }
+    }
+
+    GIVEN( "Mixed text and tabs" )
+    {
+        THEN( "Length matches untabify result" )
+        {
+            std::string input = "ab\tcd\tefgh";
+            auto length = getUntabifiedLength( input ).get();
+            REQUIRE( length == 20 );
+        }
+    }
+}
+
+SCENARIO( "getUntabifiedLength for QString matches untabify output", "[linetypes][untabify]" )
+{
+    GIVEN( "Various strings with tabs" )
+    {
+        logsquirl::vector<QString> inputs = {
+            QString( "hello" ),
+            QString( "\t" ),
+            QString( "abc\t" ),
+            QString( "\t\t" ),
+            QString( "ab\tcd\tefgh" ),
+            QString( "12345678\t" ),
+        };
+
+        THEN( "getUntabifiedLength equals untabify().size() for each input" )
+        {
+            for ( const auto& input : inputs ) {
+                auto expanded = untabify( QString( input ) );
+                auto length = getUntabifiedLength( input );
+                REQUIRE( length.get() == expanded.size() );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Rewrite untabify() from O(n*m) to O(n) single-pass algorithm. Add MaxExpandedLineLength cap (1M chars) to prevent OOM on corrupt files. Optimize doGetLineLength() to use zero-allocation length calculation. Skip regex highlighting on lines exceeding 1M characters.

Add test_data/heavy_tabs_crash.log (50k tabs, reproduces tmp/stderr.log). Add 28 new unit test assertions for untabify/getUntabifiedLength. Add 8 new e2e tests for heavy-tab file handling and performance.