### PR TITLE
fix: add libdbus-1 to Docker containers for Qt6DBus linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,13 +281,14 @@ if(UNIX)
     set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
     set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/64x-lunicorn/LogSquirl")
     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "LogSquirl Contributors <${CPACK_PACKAGE_CONTACT}>")
-    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+    # Qt is installed via aqtinstall (not distro packages), so auto-dependency
+    # detection would generate unsatisfiable requires like libQt6Core.so.6(Qt_6.10).
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS NO)
 
     #RPM
     set(CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
     set(CPACK_RPM_PACKAGE_LICENSE "GPLv3")
-    set(CPACK_RPM_PACKAGE_AUTOREQ YES)
-    #set(CPACK_RPM_PACKAGE_REQUIRES "qt5-qtbase >= ${LOGSQUIRL_QT_VERSION}")
+    set(CPACK_RPM_PACKAGE_AUTOREQ NO)
     set(CPACK_RPM_PACKAGE_URL "https://github.com/64x-lunicorn/LogSquirl")
     set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
         /usr/share/applications

--- a/docker/fedora43/Dockerfile
+++ b/docker/fedora43/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf update -y && \
     openssl-devel boost-devel zlib-devel libcurl-devel \
     gcc gcc-c++ elfutils-devel ninja-build cmake \
     mesa-libGL-devel libxkbcommon-devel fontconfig-devel freetype-devel \
-    xcb-util-cursor xcb-util-keysyms xcb-util-wm && \
+    xcb-util-cursor xcb-util-keysyms xcb-util-wm dbus-devel && \
     dnf clean all
 
 # Qt 6.10.3 via aqtinstall (same version as macOS/Windows CI)

--- a/docker/oracle10/Dockerfile
+++ b/docker/oracle10/Dockerfile
@@ -7,7 +7,7 @@ RUN dnf update -y && \
     openssl-devel boost-devel zlib-devel libcurl-devel \
     gcc gcc-c++ elfutils-devel \
     mesa-libGL-devel libxkbcommon-devel fontconfig-devel freetype-devel \
-    xcb-util-cursor xcb-util-keysyms xcb-util-wm && \
+    xcb-util-cursor xcb-util-keysyms xcb-util-wm dbus-devel && \
     dnf clean all
 
 # Qt 6.10.3 via aqtinstall (same version as macOS/Windows CI)

--- a/docker/ubuntu24.04/Dockerfile
+++ b/docker/ubuntu24.04/Dockerfile
@@ -7,9 +7,12 @@ RUN apt-get update -y && \
                     libboost-dev libicu-dev libssl-dev libcurl4-openssl-dev \
                     ragel ninja-build zlib1g-dev git pkg-config \
                     wget ca-certificates fuse libfuse2 file \
-                    libgl-dev libxkbcommon-dev libfontconfig1-dev libfreetype-dev \
+                    libgl-dev libegl-dev libdbus-1-dev \
+                    libfontconfig1-dev libfreetype-dev libglib2.0-0 \
+                    libxkbcommon-dev libxkbcommon-x11-dev \
                     libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcb-shape0 \
-                    libglib2.0-0 libdbus-1-dev libegl-dev -y && \
+                    libxcb-xkb-dev libxcb-render-util0-dev libxcb-randr0-dev \
+                    libxcb-xinerama0-dev libxcb-image0-dev libxcb-util-dev -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Qt 6.10.3 via aqtinstall (same version as macOS/Windows CI)

--- a/docker/ubuntu24.04/Dockerfile
+++ b/docker/ubuntu24.04/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -y && \
                     wget ca-certificates fuse libfuse2 file \
                     libgl-dev libxkbcommon-dev libfontconfig1-dev libfreetype-dev \
                     libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcb-shape0 \
-                    libglib2.0-0 -y && \
+                    libglib2.0-0 libdbus-1-dev -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Qt 6.10.3 via aqtinstall (same version as macOS/Windows CI)

--- a/docker/ubuntu24.04/Dockerfile
+++ b/docker/ubuntu24.04/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -y && \
                     wget ca-certificates fuse libfuse2 file \
                     libgl-dev libxkbcommon-dev libfontconfig1-dev libfreetype-dev \
                     libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcb-shape0 \
-                    libglib2.0-0 libdbus-1-dev -y && \
+                    libglib2.0-0 libdbus-1-dev libegl-dev -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Qt 6.10.3 via aqtinstall (same version as macOS/Windows CI)


### PR DESCRIPTION
Qt 6.10.3 ships libQt6DBus.so which depends on libdbus-1.so.3. Without dbus installed, linking fails with undefined references to all dbus_* symbols.