### PR TITLE
fix: Clear File (Ctrl+X) not working, SIGSEGV in LogFilteredData dest…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 26.04.2 (2026-04-19):
+
+## Bug fixes:
+ - Fixed "Clear File" (Ctrl+X) not clearing the file.  `QMessageBox::warning()`
+   only shows an OK button, so the `== QMessageBox::Yes` check always failed.
+   Replaced with `QMessageBox::question()` using explicit Yes/No buttons
+   (No as default).  (Fixes [#44](https://github.com/64x-lunicorn/LogSquirl/issues/44))
+ - Fixed SIGSEGV crash during `LogFilteredData` destruction on Windows CI.
+   The `KDSignalThrottler` member could emit a pending signal during teardown,
+   invoking a slot on the partially-destroyed object.  Added an explicit
+   destructor that disconnects all signals before member destruction.
+
+---
+
 # 26.04.1 (2026-04-19):
 
 ## New features:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 project(
   logsquirl
-  VERSION 26.04.1
+  VERSION 26.04.2
   DESCRIPTION "logsquirl log viewer"
   LANGUAGES C CXX ASM
 )

--- a/latest.json
+++ b/latest.json
@@ -1,10 +1,10 @@
 {
-  "ci": "26.04.1",
+  "ci": "26.04.2",
   "ci_url": "https://github.com/64x-lunicorn/LogSquirl/releases/tag/continuous",
-  "stable": "26.04.1",
-  "stable_url": "https://github.com/64x-lunicorn/LogSquirl/releases/tag/v26.04.1",
-  "beta": "26.04.1",
-  "beta_url": "https://github.com/64x-lunicorn/LogSquirl/releases/tag/v26.04.1",
+  "stable": "26.04.2",
+  "stable_url": "https://github.com/64x-lunicorn/LogSquirl/releases/tag/v26.04.2",
+  "beta": "26.04.2",
+  "beta_url": "https://github.com/64x-lunicorn/LogSquirl/releases/tag/v26.04.2",
   "releases": [
     "17.12.0.245",
     "19.2.0.366",
@@ -16,7 +16,8 @@
     "20.12.0.813",
     "22.06.0.1289",
     "26.03.0",
-    "26.04.1"
+    "26.04.1",
+    "26.04.2"
   ],
   "changelog": [
     {
@@ -46,8 +47,12 @@
     {
       "version": "26.04.1",
       "description": "Chart Panel, Log Merge, Tab Groups, Breadcrumbs, Vectorscan, Plugin System"
+    },
+    {
+      "version": "26.04.2",
+      "description": "Fix Clear File (Ctrl+X), fix SIGSEGV in LogFilteredData destruction"
     }
   ],
-  "stable_version": "26.04.1",
-  "beta_version": "26.04.1"
+  "stable_version": "26.04.2",
+  "beta_version": "26.04.2"
 }

--- a/src/logdata/include/logfiltereddata.h
+++ b/src/logdata/include/logfiltereddata.h
@@ -73,6 +73,10 @@ class LogFilteredData : public AbstractLogData {
     // Constructor used by LogData
     explicit LogFilteredData( const LogData* logData );
 
+    // Destructor: disconnects signals before member destruction to prevent
+    // use-after-destroy when searchProgressThrottler_ emits during teardown.
+    ~LogFilteredData() override;
+
     // Starts the async search, sending newDataAvailable() when new data found.
     // If a search is already in progress this function will block until
     // it is done, so the application should call interruptSearch() first.

--- a/src/logdata/src/logfiltereddata.cpp
+++ b/src/logdata/src/logfiltereddata.cpp
@@ -59,6 +59,16 @@
 #include "readablesize.h"
 #include "synchronization.h"
 
+LogFilteredData::~LogFilteredData()
+{
+    // Disconnect all signals before members (workerThread_, searchProgressThrottler_)
+    // are destroyed.  The throttler's destructor calls maybeEmitTriggered() which
+    // would otherwise invoke our slot on a partially-destroyed object (SIGSEGV).
+    disconnect();
+    searchProgressThrottler_.disconnect();
+    workerThread_.disconnect();
+}
+
 // Usual constructor: just copy the data, the search is started by runSearch()
 LogFilteredData::LogFilteredData( const LogData* logData )
     : AbstractLogData()

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1311,11 +1311,13 @@ void MainWindow::find()
 void MainWindow::clearLog()
 {
     const auto current_file = session_.getFilename( currentCrawlerWidget() );
-    if ( QMessageBox::warning(
-             this, tr( "logsquirl - clear file" ),
-             tr( "Clear file %1? File content will be removed from disk, this is irreversible" )
-                 .arg( current_file ) )
-         == QMessageBox::Yes ) {
+    const auto userAction = QMessageBox::question(
+        this, tr( "logsquirl - clear file" ),
+        tr( "Clear file %1? File content will be removed from disk, this is irreversible" )
+            .arg( current_file ),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
+
+    if ( userAction == QMessageBox::Yes ) {
         QFile::resize( current_file, 0 );
     }
 }


### PR DESCRIPTION
…ruction

- Replace QMessageBox::warning() with QMessageBox::question() using explicit Yes/No buttons so the Clear File action actually works. Fixes #44

- Add ~LogFilteredData() that disconnects signals before member destruction, preventing SIGSEGV when KDSignalThrottler emits triggered() during teardown on Windows CI.

- Bump version to 26.04.2, update CHANGELOG.md and latest.json.