### PR TITLE
fix: text clipping in log view and sidebar opening on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,14 @@
    rounded handles and hover highlighting.
 
 ## Bug fixes:
+ - **Text clipping in log view**: `getNbVisibleCols()` double-subtracted the
+   vertical scrollbar width from the viewport, causing text to be clipped
+   too early on the right side.  Qt's `viewport()->width()` already excludes
+   the scrollbar; the redundant subtraction has been removed.
+ - **Sidebar opens on startup when plugins register tabs**: The sidebar dock
+   was automatically shown whenever a plugin registered a sidebar tab via
+   `handlePluginSidebarTab()`.  The sidebar now stays closed by default and
+   only opens on explicit user action.
  - Fixed bright green (`#54c01a`) background on input fields in the Light
    theme caused by a corrupted QSS replace.
  - Fixed SIGSEGV crash in `MainWindow::closeTab()` when tab widget returns a

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1824,8 +1824,9 @@ LinesCount AbstractLogView::getNbVisibleLines() const
 // Returns the number of columns visible in the viewport
 LineLength AbstractLogView::getNbVisibleCols() const
 {
-    const auto scrollBarWidth = verticalScrollBar()->isVisible() ? verticalScrollBar()->width() : 0;
-    return LineLength{ ( viewport()->width() - leftMarginPx_ - scrollBarWidth ) / charWidth_ + 1 };
+    // viewport()->width() already excludes the vertical scrollbar (Qt's
+    // QAbstractScrollArea handles this), so no manual subtraction is needed.
+    return LineLength{ ( viewport()->width() - leftMarginPx_ ) / charWidth_ + 1 };
 }
 
 // Converts the mouse x, y coordinates to the line number in the file

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1652,7 +1652,6 @@ void MainWindow::handlePluginSidebarTab( const QString& pluginId,
 
     sidebarTabs_->addTab( widget, label );
     LOG_INFO << "Plugin " << pluginId << " registered sidebar tab: " << label;
-    showSidebar( sidebarTabs_->count() - 1 );
 }
 
 void MainWindow::handlePluginSidebarTabRemoved( const QString& pluginId,

--- a/tests/helpers/test_utils.h
+++ b/tests/helpers/test_utils.h
@@ -3,6 +3,11 @@
 
 #include <string>
 #include <chrono>
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QTimer>
 /*
 struct TestTimer {
     TestTimer()
@@ -45,13 +50,26 @@ class SafeQSignalSpy : public QSignalSpy {
     }
 };
 
+// Poll until checkFunc() returns true, processing Qt events between checks.
+// Uses a bounded QEventLoop instead of QTest::qWait() to ensure QTimer
+// events (e.g. KDSignalThrottler) are reliably dispatched on all platforms.
+// QTest::qWait() polls with processEvents() which can miss timer events
+// on Windows CI when the timer fires at the polling boundary (#50).
 template<typename F>
-bool waitUiState(F&& checkFunc ) {
-    for ( auto time = 0; time < 10000; time += 100 ) {
+bool waitUiState( F&& checkFunc )
+{
+    QElapsedTimer elapsed;
+    elapsed.start();
+
+    while ( elapsed.elapsed() < 20000 ) {
         if ( checkFunc() ) {
             return true;
         }
-        QTest::qWait( 100 );
+        // Run a proper event loop for 100 ms so that QTimer events are
+        // dispatched reliably.  The singleShot guard prevents hangs.
+        QEventLoop loop;
+        QTimer::singleShot( 100, &loop, &QEventLoop::quit );
+        loop.exec();
     }
     return false;
 };

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -22,4 +22,4 @@ add_test(
     COMMAND logsquirl_itests -platform offscreen
 )
 # Prevent infinite hangs in CI (e.g. from unexpected modal dialogs)
-set_tests_properties(logsquirl_itests PROPERTIES TIMEOUT 120)
+set_tests_properties(logsquirl_itests PROPERTIES TIMEOUT 240)


### PR DESCRIPTION
Remove redundant scrollbar width subtraction in getNbVisibleCols() — Qt's viewport()->width() already excludes the scrollbar, so the extra subtraction caused text to be clipped too early on the right side.

Stop auto-showing the sidebar when a plugin registers a sidebar tab. The sidebar now stays closed by default and only opens on explicit user action (toggle button or menu).