### PR TITLE
fix: viewport rendering bugs causing clipping and overflow

### DIFF
--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1701,7 +1701,7 @@ void AbstractLogView::updateDisplaySize()
 {
     // Font is assumed to be mono-space (is restricted by options dialog)
     charHeight_ = std::max( pixmapFontMetrics_.height(), 1 );
-    charWidth_ = textWidth( pixmapFontMetrics_, QString( "m" ) );
+    charWidth_ = std::max( textWidth( pixmapFontMetrics_, QString( "m" ) ), 1 );
 
     // Update the scroll bars
     updateScrollBars();
@@ -2559,7 +2559,8 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
             = fontHeight * static_cast<int>( wrappedLineView.wrappedLinesCount() );
         // LOG_INFO << "Draw line " << lineNumber << ": " << expandedLine;
 
-        painter->fillRect( xPos - ContentMarginWidth, yPos, viewport()->width(), finalLineHeight,
+        painter->fillRect( xPos - ContentMarginWidth, yPos,
+                           viewport()->width() - xPos + ContentMarginWidth, finalLineHeight,
                            backColor );
 
         LineDrawer lineDrawer( backColor );
@@ -2622,9 +2623,10 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
             auto selectionPen = QPen( palette.color( QPalette::Highlight ) );
             selectionPen.setWidth( 1 );
             painter->setPen( selectionPen );
-            painter->drawLine( xPos - ContentMarginWidth + 1, yPos, viewport()->width(), yPos );
+            painter->drawLine( xPos - ContentMarginWidth + 1, yPos,
+                               viewport()->width() - 1, yPos );
             painter->drawLine( xPos - ContentMarginWidth + 1, yPos + finalLineHeight - 1,
-                               viewport()->width(), yPos + finalLineHeight - 1 );
+                               viewport()->width() - 1, yPos + finalLineHeight - 1 );
         }
 
         // Then draw the bullet

--- a/src/ui/src/overviewwidget.cpp
+++ b/src/ui/src/overviewwidget.cpp
@@ -202,8 +202,9 @@ void OverviewWidget::paintEvent( QPaintEvent* /* paintEvent */ )
             painter.drawRect( 2, position - 2, width() - 2 - 2, 4 );
             */
             int position = overview_->yFromFileLine( *highlightedLine_ );
-            painter.drawPixmap( ( width() - HIGHLIGHT_XPM_WIDTH ) / 2,
-                                position - ( HIGHLIGHT_XPM_HEIGHT / 2 ),
+            int pixmapY = std::clamp( position - ( HIGHLIGHT_XPM_HEIGHT / 2 ), 0,
+                                       height() - HIGHLIGHT_XPM_HEIGHT );
+            painter.drawPixmap( ( width() - HIGHLIGHT_XPM_WIDTH ) / 2, pixmapY,
                                 highlight_pixmap[ INITIAL_TTL_VALUE - highlightedTTL_ ] );
         }
     }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Add test cpp file
 add_executable(logsquirl_tests
+    abstractlogview_test.cpp
     chartseries_test.cpp
     charttemplategenerator_test.cpp
     chipmunkimporter_test.cpp

--- a/tests/unit/abstractlogview_test.cpp
+++ b/tests/unit/abstractlogview_test.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 LogSquirl Contributors
+ *
+ * This file is part of LogSquirl.
+ *
+ * LogSquirl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LogSquirl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LogSquirl.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <QFont>
+#include <QWidget>
+
+#include "abstractlogview.h"
+#include "logdata.h"
+#include "quickfindpattern.h"
+
+namespace {
+
+// Minimal concrete subclass for testing AbstractLogView
+class TestLogView : public AbstractLogView {
+    Q_OBJECT
+  public:
+    TestLogView( const AbstractLogData* logData, const QuickFindPattern* qfp,
+                 QWidget* parent = nullptr )
+        : AbstractLogView( logData, qfp, parent )
+    {
+    }
+
+  protected:
+    AbstractLogData::LineType lineType( LineNumber ) const override
+    {
+        return {};
+    }
+};
+
+} // namespace
+
+SCENARIO( "AbstractLogView updateDisplaySize keeps charWidth_ safe", "[abstractlogview][viewport]" )
+{
+    LogData logData;
+    QuickFindPattern qfp;
+
+    GIVEN( "A log view widget created with default font" )
+    {
+        TestLogView view( &logData, &qfp );
+        view.resize( 800, 600 );
+
+        WHEN( "updateFont is called with a very small font" )
+        {
+            // A 1-pixel font may report zero width for "m" on some platforms
+            QFont tinyFont( "Monospace", 1 );
+            view.updateFont( tinyFont );
+
+            THEN( "the view does not crash and remains in a valid state" )
+            {
+                // If charWidth_ were 0, this would trigger a division by zero
+                // internally in getNbVisibleCols(). The show()/repaint() path
+                // exercises that code.
+                view.show();
+                view.repaint();
+                REQUIRE( true ); // Reaching here means no crash
+            }
+        }
+
+        WHEN( "updateFont is called with a normal font" )
+        {
+            QFont normalFont( "Courier", 12 );
+            view.updateFont( normalFont );
+
+            THEN( "the view renders without crashing" )
+            {
+                view.show();
+                view.repaint();
+                REQUIRE( true );
+            }
+        }
+    }
+}
+
+#include "abstractlogview_test.moc"


### PR DESCRIPTION
- Clamp charWidth_ to minimum 1 in updateDisplaySize() to prevent division by zero in getNbVisibleCols() (matched constructor behavior)
- Fix background fillRect width extending past viewport right edge
- Fix selection highlight lines drawn 1px beyond viewport boundary
- Clamp overview highlight pixmap Y position to widget bounds
- Add regression test for charWidth_ safety